### PR TITLE
Uploading File via ContainerBlobContainerFileBackend broken in Virtual Resource

### DIFF
--- a/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
+++ b/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
@@ -112,7 +112,7 @@ public class CloudBlobContainerFileBackend extends FileBackend {
     private Azure client() {
         Credentials credentials = getRootScope().getSettings(CredentialsSettings.class)
                 .getCredentialsByName()
-                .get("azure::default");
+                .get("azure::" + getCredentials());
 
         return AzureResource.createClient((AzureCredentials) credentials);
     }

--- a/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
+++ b/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
@@ -138,6 +138,4 @@ public class CloudBlobContainerFileBackend extends FileBackend {
     private String prefixed(String file) {
         return getPrefix() != null ? getPrefix() + '/' + file : file;
     }
-
-
 }

--- a/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
+++ b/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
@@ -23,6 +23,7 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import com.microsoft.azure.storage.blob.ListBlobItem;
+import com.psddev.dari.util.ObjectUtils;
 import gyro.azure.storage.StorageAccountResource;
 import gyro.core.FileBackend;
 import gyro.core.GyroException;
@@ -46,6 +47,7 @@ public class CloudBlobContainerFileBackend extends FileBackend {
     private String cloudBlobContainer;
     private String resourceGroup;
     private String prefix;
+    private String credentials;
 
     public String getStorageAccount() {
         return storageAccount;
@@ -77,6 +79,18 @@ public class CloudBlobContainerFileBackend extends FileBackend {
 
     public void setResourceGroup(String resourceGroup) {
         this.resourceGroup = resourceGroup;
+    }
+
+    public String getCredentials() {
+        if (ObjectUtils.isBlank(credentials)) {
+            setCredentials("default");
+        }
+
+        return credentials;
+    }
+
+    public void setCredentials(String credentials) {
+        this.credentials = credentials;
     }
 
     @Override


### PR DESCRIPTION
Fixes: #78

Uploading a file via CloudBlobContainerFileBackend will result in this error when used inside a virtual resource:
```Caused by: Error: Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.```
