### PR TITLE
Fixes #80: Prevent NPE when using external query for VirtualMachineImageResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [80](https://github.com/perfectsense/gyro-azure-provider/issues/80): VirtualMachineImageResource external query results in NPE
 * [58](https://github.com/perfectsense/gyro-azure-provider/issues/58): Differentiate between OS Disk and Data Disks in Azure VMs
 * [53](https://github.com/perfectsense/gyro-azure-provider/issues/53): Gyro does not clean up auto-created VM disks
 * [48](https://github.com/perfectsense/gyro-azure-provider/issues/48): Refactor Sql (QA, ResourceFinder, Direct Dependency, Copyable).

--- a/src/main/java/gyro/azure/compute/VirtualMachineImageResource.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineImageResource.java
@@ -25,6 +25,7 @@ import gyro.azure.Copyable;
 import gyro.azure.resources.ResourceGroupResource;
 import gyro.core.GyroUI;
 import gyro.core.Type;
+import gyro.core.resource.Id;
 import gyro.core.resource.Output;
 import gyro.core.resource.Resource;
 import gyro.core.scope.State;
@@ -145,6 +146,7 @@ public class VirtualMachineImageResource extends AzureResource implements Copyab
      * The ID of the virtual machine image.
      */
     @Output
+    @Id
     public String getId() {
         return id;
     }


### PR DESCRIPTION
Set Id field for VirtualMachineImage resource

https://github.com/perfectsense/gyro-azure-provider/issues/80