### PR TITLE
Fix Private DNS resolution within a provided network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [85](https://github.com/perfectsense/gyro-azure-provider/issues/85): Private DNS Zone does not associate Network
 * [80](https://github.com/perfectsense/gyro-azure-provider/issues/80): VirtualMachineImageResource external query results in NPE
 * [58](https://github.com/perfectsense/gyro-azure-provider/issues/58): Differentiate between OS Disk and Data Disks in Azure VMs
 * [53](https://github.com/perfectsense/gyro-azure-provider/issues/53): Gyro does not clean up auto-created VM disks

--- a/src/main/java/gyro/azure/dns/DnsZoneResource.java
+++ b/src/main/java/gyro/azure/dns/DnsZoneResource.java
@@ -202,10 +202,10 @@ public class DnsZoneResource extends AzureResource implements Copyable<DnsZone> 
 
         if (getPublicAccess() != null && !getPublicAccess()) {
             if (getRegistrationNetwork().isEmpty() && getResolutionNetwork().isEmpty()) {
+                withCreate.withPrivateAccess();
+            } else {
                 withCreate.withPrivateAccess(getRegistrationNetwork().stream().map(NetworkResource::getId).collect(Collectors.toList()),
                     getResolutionNetwork().stream().map(NetworkResource::getId).collect(Collectors.toList()));
-            } else {
-                withCreate.withPrivateAccess();
             }
         } else {
             withCreate.withPublicAccess();


### PR DESCRIPTION
Fixes #85 

The logic in the if / else block of associating networks with private DNS zone only applies to empty lists. This PR flips the logic to associate the networks with the private DNS zone when either the registration network(s) or resolution network(s) are populated.