### PR TITLE
Allows configuration of IP forwarding field on Network Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [87](https://github.com/perfectsense/gyro-azure-provider/issues/87): Implement IP Forwarding for Network Interfaces
 * [80](https://github.com/perfectsense/gyro-azure-provider/issues/80): VirtualMachineImageResource external query results in NPE
 * [58](https://github.com/perfectsense/gyro-azure-provider/issues/58): Differentiate between OS Disk and Data Disks in Azure VMs
 * [53](https://github.com/perfectsense/gyro-azure-provider/issues/53): Gyro does not clean up auto-created VM disks

--- a/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
+++ b/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
@@ -157,7 +157,7 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
     }
 
     /**
-     * Enables IP forwarded. Used for NAT functionality.
+     * Enables IP forwarded. Used for NAT functionality. Defaults to ``false``
      */
     @Updatable
     public Boolean getIpForwarding() {

--- a/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
+++ b/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
@@ -267,7 +267,9 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
             withCreate.withExistingLoadBalancerInboundNatRule(client.loadBalancers().getById(rule.getLoadBalancer().getId()), rule.getInboundNatRuleName());
         }
 
-        withCreate.withIPForwarding();
+        if (getIpForwarding()) {
+            withCreate.withIPForwarding();
+        }
 
         NetworkInterface networkInterface = withCreate.withTags(getTags()).create();
 


### PR DESCRIPTION
Fixes #87 

Our infrastructure uses VM's as NAT gateways. This functionality will not work unless IP forwarding is enabled on the associated network interface.

This PR allows the IP forwarding field to be configured with Gyro.