### PR TITLE
Use VMID for Gyro Instance ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [99](https://github.com/perfectsense/gyro-azure-provider/issues/99): Virtual Machine Resource ID is not suitable for Gyro Instance ID
 * [91](https://github.com/perfectsense/gyro-azure-provider/issues/91): Implement Availability Zones for Application Gateway
 * [87](https://github.com/perfectsense/gyro-azure-provider/issues/87): Implement IP Forwarding for Network Interfaces
 * [92](https://github.com/perfectsense/gyro-azure-provider/issues/92): Application Gateway - Implement SKU

--- a/src/main/java/gyro/azure/compute/VirtualMachineResource.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineResource.java
@@ -1328,7 +1328,7 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
 
     @Override
     public String getGyroInstanceId() {
-        return getId();
+        return getVmId();
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-azure-provider/issues/99

This PR changes the implementation of `GyroInstance#getGyroInstanceId()` for `VirtualMachineResource`. The current implementation uses the resource ID which is very long and not suitable for display purposes. The VMID is still unique for each Virtual Machine, and is shorter.