### PR TITLE
Update @Id field of Availability Set Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [101](https://github.com/perfectsense/gyro-azure-provider/issues/101): Availability Set Resource reference is saved to state incorrectly
 * [99](https://github.com/perfectsense/gyro-azure-provider/issues/99): Virtual Machine Resource ID is not suitable for Gyro Instance ID
 * [91](https://github.com/perfectsense/gyro-azure-provider/issues/91): Implement Availability Zones for Application Gateway
 * [87](https://github.com/perfectsense/gyro-azure-provider/issues/87): Implement IP Forwarding for Network Interfaces

--- a/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
+++ b/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
@@ -84,7 +84,6 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
     /**
      * The ID of the Availability Set.
      */
-    @Id
     @Output
     public String getId() {
         return id;
@@ -97,6 +96,7 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
     /**
      * The name of the Availability Set. (Required)
      */
+    @Id
     @Required
     public String getName() {
         return name;


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-azure-provider/issues/101

References for Availability Sets were saved to the state as the output of `AvailabilitySetResource#id` field, which was the annotated `@Id` field. This forces the Diffable Name of the resource to return as `null`. This PR changes the `@Id` annotation to the `AvailabilitySetResource#name` field, which is more inline with Azure API's for this type.