### PR TITLE
Fix Availability Set Casing to coincide with Azure VM API's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [101](https://github.com/perfectsense/gyro-azure-provider/issues/101): VirtualMachineResource#copyFrom() logic for AvailabilitySetResource fetching does not match casing of AvailabilitySetResource ID
 * [99](https://github.com/perfectsense/gyro-azure-provider/issues/99): Virtual Machine Resource ID is not suitable for Gyro Instance ID
 * [91](https://github.com/perfectsense/gyro-azure-provider/issues/91): Implement Availability Zones for Application Gateway
 * [87](https://github.com/perfectsense/gyro-azure-provider/issues/87): Implement IP Forwarding for Network Interfaces

--- a/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
+++ b/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
@@ -99,7 +99,9 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
      */
     @Required
     public String getName() {
-        return name;
+        return name != null
+                ? name.toUpperCase()
+                : name;
     }
 
     public void setName(String name) {


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-azure-provider/issues/101

Azure VM API's always uppercase the name portion of the resource ID for Availability Set. This prevented Gyro from correctly finding the availability set resource.

This PR fixes the issue by ensuring Gyro always uses the uppercased name.