### PR TITLE
Encode Scale Set Custom Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [105](https://github.com/perfectsense/gyro-azure-provider/issues/105): Scale Set Custom Data needs to be encoded
 * [101](https://github.com/perfectsense/gyro-azure-provider/issues/101): VirtualMachineResource#copyFrom() logic for AvailabilitySetResource fetching does not match casing of AvailabilitySetResource ID
 * [99](https://github.com/perfectsense/gyro-azure-provider/issues/99): Virtual Machine Resource ID is not suitable for Gyro Instance ID
 * [91](https://github.com/perfectsense/gyro-azure-provider/issues/91): Implement Availability Zones for Application Gateway

--- a/src/main/java/gyro/azure/compute/VMScaleSetResource.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetResource.java
@@ -48,6 +48,7 @@ import gyro.core.validation.Required;
 import gyro.core.validation.ValidStrings;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -764,6 +765,14 @@ public class VMScaleSetResource extends AzureResource implements Copyable<Virtua
         this.id = id;
     }
 
+    private String getEncodedCustomData() {
+        return !ObjectUtils.isBlank(getCustomData()) ? Base64.getEncoder().encodeToString(getCustomData().getBytes()) : null;
+    }
+
+    private String getDecodedCustomData(String data) {
+        return !ObjectUtils.isBlank(data) ? new String(Base64.getDecoder().decode(data.getBytes())) : null;
+    }
+
     @Override
     public void copyFrom(VirtualMachineScaleSet scaleSet) {
         try {
@@ -849,7 +858,7 @@ public class VMScaleSetResource extends AzureResource implements Copyable<Virtua
     @Override
     public void create(GyroUI ui, State state) {
         Azure client = createClient();
-
+        
         VirtualMachineScaleSet.DefinitionStages.WithProximityPlacementGroup withProximityPlacementGroup = client.virtualMachineScaleSets().define(getName())
             .withRegion(Region.fromName(getRegion()))
             .withExistingResourceGroup(getResourceGroup().getName())
@@ -1026,9 +1035,7 @@ public class VMScaleSetResource extends AzureResource implements Copyable<Virtua
             finalStage = finalStage.withComputerNamePrefix(getComputerNamePrefix());
         }
 
-        if (!ObjectUtils.isBlank(getCustomData())) {
-            finalStage = finalStage.withCustomData(getCustomData());
-        }
+        finalStage = finalStage.withCustomData(getEncodedCustomData());
 
         if (getEnableIpForwarding()) {
             finalStage = finalStage.withIpForwarding();


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-azure-provider/issues/105

The Azure API expects the Scale Set Custom Data to be base64 encoded. This PR encodes the String that is defined by the Gyro field before creating the Scale Set.