### PR TITLE
Check if the IpAddress from the PublicIpAddress resource is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ISSUES FIXED:
 
+* [109](https://github.com/perfectsense/gyro-azure-provider/issues/110): VirtualMachine#getGyroInstancePublicIpAddress returns null even if publicIpAdressIp has a value.
 * [105](https://github.com/perfectsense/gyro-azure-provider/issues/105): Scale Set Custom Data needs to be encoded
 * [101](https://github.com/perfectsense/gyro-azure-provider/issues/101): VirtualMachineResource#copyFrom() logic for AvailabilitySetResource fetching does not match casing of AvailabilitySetResource ID
 * [99](https://github.com/perfectsense/gyro-azure-provider/issues/99): Virtual Machine Resource ID is not suitable for Gyro Instance ID

--- a/src/main/java/gyro/azure/compute/VirtualMachineResource.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineResource.java
@@ -1343,7 +1343,7 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
 
     @Override
     public String getGyroInstancePublicIpAddress() {
-        return getPublicIpAddress() != null ? getPublicIpAddress().getIpAddress() : getPublicIpAddressIp();
+        return getPublicIpAddress() != null && !ObjectUtils.isBlank(getPublicIpAddress().getIpAddress()) ? getPublicIpAddress().getIpAddress() : getPublicIpAddressIp();
     }
 
     @Override


### PR DESCRIPTION
Fixes #109 

`getGyroInstancePublicIpAddress()` should return the Virtual Machine's public Ip Address if PublicIpAdress is null, or if it's `IpAddresss` field is also null. This behavior fixes any instances where PublicIpAddress only has its ID field populated, so the method returns `null` rather than using `PublicIpAddressIp`