### PR TITLE
Remove storage account keys

### DIFF
--- a/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
+++ b/src/main/java/gyro/azure/CloudBlobContainerFileBackend.java
@@ -134,10 +134,8 @@ public class CloudBlobContainerFileBackend extends FileBackend {
     private CloudBlobContainer container() {
         StorageAccountResource storage = getRootScope().findResourceById(StorageAccountResource.class, getStorageAccount());
 
-        if(storage.getKeys() == null || storage.getKeys().isEmpty()) {
-            StorageAccount storageAccount = client().storageAccounts().getByResourceGroup(getResourceGroup(), getStorageAccount());
-            storage.copyFrom(storageAccount);
-        }
+        StorageAccount storageAccount = client().storageAccounts().getByResourceGroup(getResourceGroup(), getStorageAccount());
+        storage.copyFrom(storageAccount);
 
         try {
             CloudStorageAccount account = CloudStorageAccount.parse(storage.getConnection());

--- a/src/main/java/gyro/azure/sql/SqlDatabaseResource.java
+++ b/src/main/java/gyro/azure/sql/SqlDatabaseResource.java
@@ -368,7 +368,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
                         getImportFromFilename())
                         .withSqlAdministratorLoginAndPassword(getSqlServer().getAdministratorLogin(), getSqlServer().getAdministratorPassword());
             } else if (getStorageUri() != null && getStorageAccount() != null) {
-                buildDatabase.importFrom(getStorageUri()).withStorageAccessKey(getStorageAccount().getKeys().get("key1"))
+                buildDatabase.importFrom(getStorageUri()).withStorageAccessKey(getStorageAccount().keys().get("key1"))
                 .withSqlAdministratorLoginAndPassword(getSqlServer().getAdministratorLogin(), getSqlServer().getAdministratorPassword());
             } else if (getWithSampleDatabase() != null) {
                 withExistingDatabaseAfterElasticPool.fromSample(SampleName.ADVENTURE_WORKS_LT);
@@ -417,7 +417,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
             buildDatabase.importFrom(storageAccount, getImportFromContainerName(), getImportFromFilename())
                     .withSqlAdministratorLoginAndPassword(getSqlServer().getAdministratorLogin(), getSqlServer().getAdministratorPassword());
         } else if (getStorageUri() != null && getStorageAccount() != null) {
-            buildDatabase.importFrom(getStorageUri()).withStorageAccessKey(getStorageAccount().getKeys().get("key1"))
+            buildDatabase.importFrom(getStorageUri()).withStorageAccessKey(getStorageAccount().keys().get("key1"))
                     .withSqlAdministratorLoginAndPassword(getSqlServer().getAdministratorLogin(), getSqlServer().getAdministratorPassword());
         } else if (getWithSampleDatabase() != null) {
             buildDatabase.fromSample(SampleName.ADVENTURE_WORKS_LT);


### PR DESCRIPTION
Fixes #104 

Remove key as an output field, and instead provide a method to fetch the key values when needed.