### PR TITLE
Allow gyro SSH/List to show scaling set virtual machines

### DIFF
--- a/src/main/java/gyro/azure/compute/VMScaleSetResource.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetResource.java
@@ -22,7 +22,6 @@ import com.microsoft.azure.management.compute.CachingTypes;
 import com.microsoft.azure.management.compute.KnownLinuxVirtualMachineImage;
 import com.microsoft.azure.management.compute.KnownWindowsVirtualMachineImage;
 import com.microsoft.azure.management.compute.ProximityPlacementGroupType;
-import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineEvictionPolicyTypes;
 import com.microsoft.azure.management.compute.VirtualMachineScaleSet;
 import com.microsoft.azure.management.compute.VirtualMachineScaleSetSkuTypes;
@@ -1214,11 +1213,10 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
                 .map(VirtualMachineScaleSetVM::instanceId)
                 .collect(Collectors.toList());
 
-            instances.addAll(instanceIds.stream()
+            instances.addAll(list.stream()
                 .map(o -> {
-                    VirtualMachine virtualMachine = client.virtualMachines().getById(o);
-                    VirtualMachineResource vmResource = newSubresource(VirtualMachineResource.class);
-                    vmResource.copyFrom(virtualMachine);
+                    VMScaleSetVirtualMachine vmResource = newSubresource(VMScaleSetVirtualMachine.class);
+                    vmResource.copyFrom(o);
                     return vmResource;
                 }).collect(Collectors.toList()));
         }

--- a/src/main/java/gyro/azure/compute/VMScaleSetVirtualMachine.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetVirtualMachine.java
@@ -1,0 +1,135 @@
+package gyro.azure.compute;
+
+import java.util.Collection;
+
+import com.microsoft.azure.management.compute.VirtualMachineScaleSetVM;
+import com.microsoft.azure.management.network.implementation.NetworkInterfaceIPConfigurationInner;
+import gyro.azure.Copyable;
+import gyro.core.GyroInstance;
+import gyro.core.resource.Diffable;
+
+public class VMScaleSetVirtualMachine extends Diffable implements GyroInstance, Copyable<VirtualMachineScaleSetVM> {
+
+    private String name;
+    private String instanceId;
+    private String state;
+    private String privateIp;
+    private String publicIp;
+    private String location;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public void setInstanceId(String instanceId) {
+        this.instanceId = instanceId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getPrivateIp() {
+        return privateIp;
+    }
+
+    public void setPrivateIp(String privateIp) {
+        this.privateIp = privateIp;
+    }
+
+    public String getPublicIp() {
+        return publicIp;
+    }
+
+    public void setPublicIp(String publicIp) {
+        this.publicIp = publicIp;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public void copyFrom(VirtualMachineScaleSetVM model) {
+        setName(model.computerName());
+        setInstanceId(model.instanceId());
+        setState(model.powerState().toString());
+        setLocation(model.inner().location());
+        //model
+        NetworkInterfaceIPConfigurationInner ipConfig = model.listNetworkInterfaces()
+            .stream()
+            .filter(nic -> nic.name().equals("primary-nic-cfg"))
+            .map(nic -> nic.inner().ipConfigurations())
+            .flatMap(Collection::stream)
+            .filter(NetworkInterfaceIPConfigurationInner::primary)
+            .findFirst()
+            .orElse(null);
+
+        if (ipConfig != null) {
+            setPrivateIp(ipConfig.privateIPAddress());
+            setPublicIp(ipConfig.publicIPAddress() != null ? ipConfig.publicIPAddress().ipAddress() : null);
+        }
+
+    }
+
+    @Override
+    public String getGyroInstanceId() {
+        return getInstanceId();
+    }
+
+    @Override
+    public String getGyroInstanceState() {
+        return getState();
+    }
+
+    @Override
+    public String getGyroInstancePrivateIpAddress() {
+        return getPrivateIp();
+    }
+
+    @Override
+    public String getGyroInstancePublicIpAddress() {
+        return getPublicIp();
+    }
+
+    @Override
+    public String getGyroInstanceHostname() {
+        return getGyroInstancePublicIpAddress() != null ? getGyroInstancePublicIpAddress() : getGyroInstancePrivateIpAddress();
+    }
+
+    @Override
+    public String getGyroInstanceName() {
+        return getName();
+    }
+
+    @Override
+    public String getGyroInstanceLaunchDate() {
+        return null;
+    }
+
+    @Override
+    public String getGyroInstanceLocation() {
+        return getLocation();
+    }
+
+    @Override
+    public String primaryKey() {
+        return getGyroInstanceId();
+    }
+}


### PR DESCRIPTION
Fixes #117 

This allows gyro `ssh/list` cmd to list instances created using scale sets