### PR TITLE
Support multiple client types for base implementations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 
     implementation enforcedPlatform('com.azure:azure-sdk-bom:1.2.25')
     implementation 'com.azure.resourcemanager:azure-resourcemanager:2.40.0'
+    implementation 'com.azure.resourcemanager:azure-resourcemanager-communication:2.1.0'
     implementation 'com.azure:azure-security-keyvault-certificates'
     implementation 'com.azure:azure-security-keyvault-keys'
     implementation 'com.azure:azure-security-keyvault-secrets'

--- a/src/main/java/gyro/azure/AbstractAzureCommand.java
+++ b/src/main/java/gyro/azure/AbstractAzureCommand.java
@@ -97,7 +97,7 @@ public abstract class AbstractAzureCommand {
                 getCredential()));
         }
 
-        return AzureResource.createClient((AzureCredentials) credentials);
+        return AzureResource.createClient(AzureResourceManager.class, (AzureCredentials) credentials);
     }
 
     public TokenCredential getTokenCredential() {

--- a/src/main/java/gyro/azure/AzureCredentials.java
+++ b/src/main/java/gyro/azure/AzureCredentials.java
@@ -102,7 +102,7 @@ public class AzureCredentials extends Credentials {
                 throw new GyroException(error.getMessage(), error);
             }
 
-        } else {
+        } else if (clientClass.getSimpleName().equals("AzureResourceManager")) {
             try {
                 AzureResourceManager.Authenticated authenticated = AzureResourceManager
                     .configure()
@@ -124,6 +124,10 @@ public class AzureCredentials extends Credentials {
             } catch (Exception error) {
                 throw new GyroException(error.getMessage(), error);
             }
+
+        } else {
+            throw new UnsupportedOperationException(
+                String.format("The following client type is not available: %s", clientClass.getSimpleName()));
         }
     }
 

--- a/src/main/java/gyro/azure/AzureCredentials.java
+++ b/src/main/java/gyro/azure/AzureCredentials.java
@@ -22,9 +22,11 @@ import java.util.Properties;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
+import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.communication.CommunicationManager;
 import com.psddev.dari.util.ObjectUtils;
 import com.psddev.dari.util.StringUtils;
 import gyro.core.GyroException;
@@ -60,7 +62,7 @@ public class AzureCredentials extends Credentials {
         this.logLevel = logLevel;
     }
 
-    public AzureResourceManager createClient() {
+    public <T> T createClient(Class<T> clientClass) {
         Properties properties;
 
         try (InputStream input = openInput(getCredentialFilePath())) {
@@ -80,21 +82,48 @@ public class AzureCredentials extends Credentials {
 
         String subscription = ObjectUtils.to(String.class, properties.get("subscription"));
 
-        AzureProfile azureProfile = new AzureProfile(tenant, subscription, com.azure.core.management.AzureEnvironment.AZURE);
+        AzureProfile azureProfile = new AzureProfile(tenant, subscription, AzureEnvironment.AZURE);
 
-        try {
-            AzureResourceManager.Authenticated authenticated = AzureResourceManager
-                .configure()
-                .withHttpClient(new OkHttpAsyncHttpClientBuilder().build())
-                .authenticate(credential, azureProfile);
+        if (clientClass.getSimpleName().equals("CommunicationManager")) {
+            try {
+                CommunicationManager client = CommunicationManager
+                    .configure()
+                    .withHttpClient(new OkHttpAsyncHttpClientBuilder().build())
+                    .authenticate(credential, azureProfile);
+
+                if (clientClass.isInstance(client)) {
+                    return clientClass.cast(client);
+                }
+
+                throw new GyroException(
+                    String.format("Unable to create %s client", clientClass.getSimpleName()));
+
+            } catch (Exception error) {
+                throw new GyroException(error.getMessage(), error);
+            }
+
+        } else {
+            try {
+                AzureResourceManager.Authenticated authenticated = AzureResourceManager
+                    .configure()
+                    .withHttpClient(new OkHttpAsyncHttpClientBuilder().build())
+                    .authenticate(credential, azureProfile);
 
 
-            return StringUtils.isBlank(subscription)
-                ? authenticated.withDefaultSubscription()
-                : authenticated.withSubscription(subscription);
+                AzureResourceManager client = StringUtils.isBlank(subscription)
+                    ? authenticated.withDefaultSubscription()
+                    : authenticated.withSubscription(subscription);
 
-        } catch (Exception error) {
-            throw new GyroException(error.getMessage(), error);
+                if (clientClass.isInstance(client)) {
+                    return clientClass.cast(client);
+                }
+
+                throw new GyroException(
+                    String.format("Unable to create %s client", clientClass.getSimpleName()));
+
+            } catch (Exception error) {
+                throw new GyroException(error.getMessage(), error);
+            }
         }
     }
 

--- a/src/main/java/gyro/azure/AzureFinder.java
+++ b/src/main/java/gyro/azure/AzureFinder.java
@@ -22,13 +22,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.azure.core.credential.TokenCredential;
-import com.azure.resourcemanager.AzureResourceManager;
+import com.psddev.dari.util.TypeDefinition;
 import gyro.core.finder.Finder;
 
-public abstract class AzureFinder<M, R extends AzureResource> extends Finder<R> {
-    protected abstract List<M> findAllAzure(AzureResourceManager client);
+public abstract class AzureFinder<C, M, R extends AzureResource> extends Finder<R> {
+    protected abstract List<M> findAllAzure(C client);
 
-    protected abstract List<M> findAzure(AzureResourceManager client, Map<String, String> filters);
+    protected abstract List<M> findAzure(C client, Map<String, String> filters);
 
     @Override
     public List<R> find(Map<String, Object> filters) {
@@ -44,8 +44,12 @@ public abstract class AzureFinder<M, R extends AzureResource> extends Finder<R> 
             .collect(Collectors.toList());
     }
 
-    private AzureResourceManager newClient() {
-        return AzureResource.createClient(credentials(AzureCredentials.class));
+    private C newClient() {
+        @SuppressWarnings("unchecked")
+        Class<C> clientClass = (Class<C>) TypeDefinition.getInstance(getClass())
+            .getInferredGenericTypeArgumentClass(AzureFinder.class, 0);
+
+        return AzureResource.createClient(clientClass, credentials(AzureCredentials.class));
     }
 
     protected TokenCredential getTokenCredential() {

--- a/src/main/java/gyro/azure/AzureResource.java
+++ b/src/main/java/gyro/azure/AzureResource.java
@@ -18,6 +18,7 @@ package gyro.azure;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.resourcemanager.AzureResourceManager;
+import com.azure.resourcemanager.communication.CommunicationManager;
 import gyro.core.resource.Resource;
 
 public abstract class AzureResource extends Resource {
@@ -26,12 +27,20 @@ public abstract class AzureResource extends Resource {
         return credentials(AzureCredentials.class).getRegion();
     }
 
-    public static AzureResourceManager createClient(AzureCredentials credentials) {
-        return credentials.createClient();
+    public static <T> T createClient(Class<T> clientClass, AzureCredentials credentials) {
+        return credentials.createClient(clientClass);
+    }
+
+    protected <T> T createClient(Class<T> clientClass) {
+        return AzureResource.createClient(clientClass, credentials(AzureCredentials.class));
     }
 
     protected AzureResourceManager createClient() {
-        return AzureResource.createClient(credentials(AzureCredentials.class));
+        return AzureResource.createClient(AzureResourceManager.class, credentials(AzureCredentials.class));
+    }
+
+    protected CommunicationManager createCommunicationClient() {
+        return AzureResource.createClient(CommunicationManager.class, credentials(AzureCredentials.class));
     }
 
     public static TokenCredential getTokenCredential(AzureCredentials credentials) {

--- a/src/main/java/gyro/azure/AzureResource.java
+++ b/src/main/java/gyro/azure/AzureResource.java
@@ -35,14 +35,6 @@ public abstract class AzureResource extends Resource {
         return AzureResource.createClient(clientClass, credentials(AzureCredentials.class));
     }
 
-    protected AzureResourceManager createClient() {
-        return AzureResource.createClient(AzureResourceManager.class, credentials(AzureCredentials.class));
-    }
-
-    protected CommunicationManager createCommunicationClient() {
-        return AzureResource.createClient(CommunicationManager.class, credentials(AzureCredentials.class));
-    }
-
     public static TokenCredential getTokenCredential(AzureCredentials credentials) {
         return credentials.getTokenCredential();
     }

--- a/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryGroupFinder.java
+++ b/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryGroupFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  */
 @Type("active-directory-group")
 public class ActiveDirectoryGroupFinder
-    extends AzureFinder<ActiveDirectoryGroup, ActiveDirectoryGroupResource> {
+    extends AzureFinder<AzureResourceManager, ActiveDirectoryGroup, ActiveDirectoryGroupResource> {
 
     private String name;
     private String id;

--- a/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryGroupResource.java
+++ b/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryGroupResource.java
@@ -95,7 +95,7 @@ public class ActiveDirectoryGroupResource extends AzureResource implements Copya
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryGroup group = client.accessManagement().activeDirectoryGroups().getById(getId());
 
@@ -110,7 +110,7 @@ public class ActiveDirectoryGroupResource extends AzureResource implements Copya
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryGroup group = client.accessManagement().activeDirectoryGroups()
             .define(getName())
@@ -127,7 +127,7 @@ public class ActiveDirectoryGroupResource extends AzureResource implements Copya
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.accessManagement().activeDirectoryGroups().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryUserFinder.java
+++ b/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryUserFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  */
 @Type("active-directory-user")
 public class ActiveDirectoryUserFinder
-    extends AzureFinder<ActiveDirectoryUser, ActiveDirectoryUserResource> {
+    extends AzureFinder<AzureResourceManager, ActiveDirectoryUser, ActiveDirectoryUserResource> {
 
     private String id;
     private String name;

--- a/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryUserResource.java
+++ b/src/main/java/gyro/azure/accessmanagement/ActiveDirectoryUserResource.java
@@ -141,7 +141,7 @@ public class ActiveDirectoryUserResource extends AzureResource implements Copyab
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryUser user = client.accessManagement().activeDirectoryUsers().getById(getId());
 
@@ -156,7 +156,7 @@ public class ActiveDirectoryUserResource extends AzureResource implements Copyab
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryUser activeDirectoryUser = client.accessManagement().activeDirectoryUsers()
             .define(getName())
@@ -175,7 +175,7 @@ public class ActiveDirectoryUserResource extends AzureResource implements Copyab
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.accessManagement().activeDirectoryUsers().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/accessmanagement/ApplicationFinder.java
+++ b/src/main/java/gyro/azure/accessmanagement/ApplicationFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    application: $(external-query azure::application {})
  */
 @Type("application")
-public class ApplicationFinder extends AzureFinder<ActiveDirectoryApplication, ApplicationResource> {
+public class ApplicationFinder extends AzureFinder<AzureResourceManager, ActiveDirectoryApplication, ApplicationResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/accessmanagement/ApplicationResource.java
+++ b/src/main/java/gyro/azure/accessmanagement/ApplicationResource.java
@@ -171,7 +171,7 @@ public class ApplicationResource extends AzureResource implements Copyable<Activ
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryApplication application = client.accessManagement()
             .activeDirectoryApplications()
@@ -188,7 +188,7 @@ public class ApplicationResource extends AzureResource implements Copyable<Activ
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryApplication.DefinitionStages.WithCreate withCreate = client.accessManagement()
             .activeDirectoryApplications()
@@ -215,7 +215,7 @@ public class ApplicationResource extends AzureResource implements Copyable<Activ
     @Override
     public void update(
         GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ActiveDirectoryApplication application = client.accessManagement()
             .activeDirectoryApplications()
@@ -258,7 +258,7 @@ public class ApplicationResource extends AzureResource implements Copyable<Activ
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.accessManagement().activeDirectoryApplications().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/accessmanagement/RoleAssignmentResource.java
+++ b/src/main/java/gyro/azure/accessmanagement/RoleAssignmentResource.java
@@ -152,7 +152,7 @@ public class RoleAssignmentResource extends AzureResource implements Copyable<Ro
         setScope(roleAssignment.scope());
         setId(roleAssignment.id());
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
         setRole(client.accessManagement().roleDefinitions().getById(roleAssignment.roleDefinitionId()).roleName());
 
         ActiveDirectoryUser user = null;
@@ -180,7 +180,7 @@ public class RoleAssignmentResource extends AzureResource implements Copyable<Ro
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         RoleAssignment roleAssignment = client.accessManagement().roleAssignments().getByScope(getScope(), getName());
 
@@ -195,7 +195,7 @@ public class RoleAssignmentResource extends AzureResource implements Copyable<Ro
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         if (Stream.of(getPrincipalId(), getUser(), getGroup()).filter(Objects::nonNull).count() > 1) {
             throw new GyroException("Only one of 'principal-id' or 'user' or 'group' is allowed.");
@@ -254,7 +254,7 @@ public class RoleAssignmentResource extends AzureResource implements Copyable<Ro
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.accessManagement().roleAssignments().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/accessmanagement/ServicePrincipalFinder.java
+++ b/src/main/java/gyro/azure/accessmanagement/ServicePrincipalFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    service-principal: $(external-query azure::service-principal {})
  */
 @Type("service-principal")
-public class ServicePrincipalFinder extends AzureFinder<ServicePrincipal, ServicePrincipalResource> {
+public class ServicePrincipalFinder extends AzureFinder<AzureResourceManager, ServicePrincipal, ServicePrincipalResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/accessmanagement/ServicePrincipalResource.java
+++ b/src/main/java/gyro/azure/accessmanagement/ServicePrincipalResource.java
@@ -98,7 +98,7 @@ public class ServicePrincipalResource extends AzureResource implements Copyable<
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ServicePrincipal servicePrincipal = client.accessManagement().servicePrincipals().getByName(getName());
 
@@ -113,7 +113,7 @@ public class ServicePrincipalResource extends AzureResource implements Copyable<
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ServicePrincipal servicePrincipal = client.accessManagement().servicePrincipals()
             .define(getName())
@@ -131,7 +131,7 @@ public class ServicePrincipalResource extends AzureResource implements Copyable<
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.accessManagement().servicePrincipals().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/cdn/CdnEndpointResource.java
+++ b/src/main/java/gyro/azure/cdn/CdnEndpointResource.java
@@ -339,7 +339,7 @@ public class CdnEndpointResource extends AzureResource implements Copyable<CdnEn
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfileResource parent = (CdnProfileResource) parent();
 
@@ -432,7 +432,7 @@ public class CdnEndpointResource extends AzureResource implements Copyable<CdnEn
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfileResource parent = (CdnProfileResource) parent();
 
@@ -524,7 +524,7 @@ public class CdnEndpointResource extends AzureResource implements Copyable<CdnEn
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfileResource parent = (CdnProfileResource) parent();
 

--- a/src/main/java/gyro/azure/cdn/CdnProfileFinder.java
+++ b/src/main/java/gyro/azure/cdn/CdnProfileFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    cdn-profile: $(external-query azure::cdn-profile {})
  */
 @Type("cdn-profile")
-public class CdnProfileFinder extends AzureFinder<CdnProfile, CdnProfileResource> {
+public class CdnProfileFinder extends AzureFinder<AzureResourceManager, CdnProfile, CdnProfileResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/cdn/CdnProfileResource.java
+++ b/src/main/java/gyro/azure/cdn/CdnProfileResource.java
@@ -165,7 +165,7 @@ public class CdnProfileResource extends AzureResource implements Copyable<CdnPro
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfile cdnProfile = client.cdnProfiles().getById(getId());
 
@@ -180,7 +180,7 @@ public class CdnProfileResource extends AzureResource implements Copyable<CdnPro
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfile.DefinitionStages.WithSku withSku = client.cdnProfiles().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -202,7 +202,7 @@ public class CdnProfileResource extends AzureResource implements Copyable<CdnPro
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CdnProfile.Update update = client.cdnProfiles().getById(getId()).update().withTags(getTags());
         update.apply();
@@ -210,7 +210,7 @@ public class CdnProfileResource extends AzureResource implements Copyable<CdnPro
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.cdnProfiles().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/AvailabilitySetFinder.java
+++ b/src/main/java/gyro/azure/compute/AvailabilitySetFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    availability-set: $(external-query azure::availability-set {})
  */
 @Type("availability-set")
-public class AvailabilitySetFinder extends AzureFinder<AvailabilitySet, AvailabilitySetResource> {
+public class AvailabilitySetFinder extends AzureFinder<AzureResourceManager, AvailabilitySet, AvailabilitySetResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
+++ b/src/main/java/gyro/azure/compute/AvailabilitySetResource.java
@@ -175,7 +175,7 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AvailabilitySet availabilitySet = client.availabilitySets().getById(getId());
 
@@ -190,7 +190,7 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AvailabilitySet availabilitySet = client.availabilitySets().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -206,7 +206,7 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         if (changedFieldNames.contains("sku") && AvailabilitySetSkuTypes.fromString(getSku())
             .equals(AvailabilitySetSkuTypes.CLASSIC)) {
@@ -223,7 +223,7 @@ public class AvailabilitySetResource extends AzureResource implements Copyable<A
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.availabilitySets().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/DiskFinder.java
+++ b/src/main/java/gyro/azure/compute/DiskFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    disk: $(external-query azure::disk {})
  */
 @Type("disk")
-public class DiskFinder extends AzureFinder<Disk, DiskResource> {
+public class DiskFinder extends AzureFinder<AzureResourceManager, Disk, DiskResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/DiskResource.java
+++ b/src/main/java/gyro/azure/compute/DiskResource.java
@@ -221,7 +221,7 @@ public class DiskResource extends AzureResource implements Copyable<Disk> {
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Disk disk = client.disks().getById(getId());
 
@@ -236,7 +236,7 @@ public class DiskResource extends AzureResource implements Copyable<Disk> {
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Disk.DefinitionStages.WithDiskSource diskDefWithoutData = client.disks()
             .define(getName())
@@ -291,7 +291,7 @@ public class DiskResource extends AzureResource implements Copyable<Disk> {
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Disk disk = client.disks().getById(getId());
 
@@ -318,7 +318,7 @@ public class DiskResource extends AzureResource implements Copyable<Disk> {
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.disks().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/SnapshotFinder.java
+++ b/src/main/java/gyro/azure/compute/SnapshotFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    snapshot: $(external-query azure::snapshot {})
  */
 @Type("snapshot")
-public class SnapshotFinder extends AzureFinder<Snapshot, SnapshotResource> {
+public class SnapshotFinder extends AzureFinder<AzureResourceManager, Snapshot, SnapshotResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/SnapshotResource.java
+++ b/src/main/java/gyro/azure/compute/SnapshotResource.java
@@ -253,7 +253,7 @@ public class SnapshotResource extends AzureResource implements Copyable<Snapshot
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Snapshot snapshot = client.snapshots().getById(getId());
 
@@ -268,7 +268,7 @@ public class SnapshotResource extends AzureResource implements Copyable<Snapshot
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Snapshot.DefinitionStages.WithSnapshotSource withSnapshotSource = client.snapshots().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -329,7 +329,7 @@ public class SnapshotResource extends AzureResource implements Copyable<Snapshot
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.snapshots().getById(getId())
             .update()
@@ -340,7 +340,7 @@ public class SnapshotResource extends AzureResource implements Copyable<Snapshot
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.snapshots().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/VMScaleSetFinder.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    scale-set: $(external-query azure::scale-set {})
  */
 @Type("scale-set")
-public class VMScaleSetFinder extends AzureFinder<VirtualMachineScaleSet, VMScaleSetResource> {
+public class VMScaleSetFinder extends AzureFinder<AzureResourceManager, VirtualMachineScaleSet, VMScaleSetResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/VMScaleSetResource.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetResource.java
@@ -858,7 +858,7 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineScaleSet scaleSet = client.virtualMachineScaleSets().getById(getId());
 
@@ -873,7 +873,7 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineScaleSet.DefinitionStages.WithProximityPlacementGroup withProximityPlacementGroup = client.virtualMachineScaleSets()
             .define(getName())
@@ -1114,7 +1114,7 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineScaleSet scaleSet = client.virtualMachineScaleSets().getById(getId());
 
@@ -1243,7 +1243,7 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.virtualMachineScaleSets().deleteById(getId());
     }
@@ -1251,7 +1251,7 @@ public class VMScaleSetResource extends AzureResource implements GyroInstances, 
     @Override
     public List<GyroInstance> getInstances() {
         List<GyroInstance> instances = new ArrayList<>();
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineScaleSet virtualMachineScaleSet = client.virtualMachineScaleSets().getById(getId());
 

--- a/src/main/java/gyro/azure/compute/VMScaleSetScalingFinder.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetScalingFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    scale-set-scaling: $(external-query azure::scale-set-scaling {})
  */
 @Type("scale-set-scaling")
-public class VMScaleSetScalingFinder extends AzureFinder<AutoscaleSetting, VMScaleSetScalingResource> {
+public class VMScaleSetScalingFinder extends AzureFinder<AzureResourceManager, AutoscaleSetting, VMScaleSetScalingResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/VMScaleSetScalingResource.java
+++ b/src/main/java/gyro/azure/compute/VMScaleSetScalingResource.java
@@ -314,7 +314,7 @@ public class VMScaleSetScalingResource extends AzureResource implements Copyable
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AutoscaleSetting autoscaleSetting = client.autoscaleSettings().getById(getId());
 
@@ -329,7 +329,7 @@ public class VMScaleSetScalingResource extends AzureResource implements Copyable
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AutoscaleSetting.DefinitionStages.DefineAutoscaleSettingResourceProfiles basicStage = client.autoscaleSettings()
             .define(getName())
@@ -420,7 +420,7 @@ public class VMScaleSetScalingResource extends AzureResource implements Copyable
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AutoscaleSetting autoscaleSetting = client.autoscaleSettings().getById(getId());
 
@@ -515,7 +515,7 @@ public class VMScaleSetScalingResource extends AzureResource implements Copyable
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.autoscaleSettings().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/VirtualMachineFinder.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    virtual-machine: $(external-query azure::virtual-machine {})
  */
 @Type("virtual-machine")
-public class VirtualMachineFinder extends AzureFinder<VirtualMachine, VirtualMachineResource> {
+public class VirtualMachineFinder extends AzureFinder<AzureResourceManager, VirtualMachine, VirtualMachineResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/VirtualMachineImageFinder.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineImageFinder.java
@@ -38,7 +38,7 @@ import gyro.core.Type;
  */
 @Type("virtual-machine-image")
 public class VirtualMachineImageFinder
-    extends AzureFinder<VirtualMachineCustomImage, VirtualMachineImageResource> {
+    extends AzureFinder<AzureResourceManager, VirtualMachineCustomImage, VirtualMachineImageResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/compute/VirtualMachineImageResource.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineImageResource.java
@@ -170,7 +170,7 @@ public class VirtualMachineImageResource extends AzureResource implements Copyab
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineCustomImage image = client.virtualMachineCustomImages().getById(getId());
 
@@ -185,7 +185,7 @@ public class VirtualMachineImageResource extends AzureResource implements Copyab
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachineCustomImage.DefinitionStages.WithCreate withCreate = client.virtualMachineCustomImages()
             .define(getName())
@@ -214,7 +214,7 @@ public class VirtualMachineImageResource extends AzureResource implements Copyab
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.virtualMachineCustomImages().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/compute/VirtualMachineResource.java
+++ b/src/main/java/gyro/azure/compute/VirtualMachineResource.java
@@ -766,13 +766,13 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
             .orElse(null);
         setLaunchDate(instanceViewStatus != null ? Date.from(instanceViewStatus.time().toInstant()) : null);
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
         setPrivateIpAddress(client.networkInterfaces().getById(getNetworkInterface().getId()).primaryPrivateIP());
     }
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachine virtualMachine = client.virtualMachines().getById(getId());
 
@@ -787,7 +787,7 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
 
     @Override
     public void create(GyroUI ui, State state) {
-        VirtualMachine virtualMachine = doVMFluentWorkflow(createClient()).create();
+        VirtualMachine virtualMachine = doVMFluentWorkflow(createClient(AzureResourceManager.class)).create();
         setId(virtualMachine.id());
         setVmId(virtualMachine.vmId());
         copyFrom(virtualMachine);
@@ -1237,7 +1237,7 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachine virtualMachine = client.virtualMachines().getById(getId());
 
@@ -1302,7 +1302,7 @@ public class VirtualMachineResource extends AzureResource implements GyroInstanc
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         VirtualMachine virtualMachine = client.virtualMachines().getById(getId());
         client.virtualMachines().deleteById(getId());

--- a/src/main/java/gyro/azure/containerservice/KubernetesClusterFinder.java
+++ b/src/main/java/gyro/azure/containerservice/KubernetesClusterFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    kubernetes-cluster: $(external-query azure::kubernetes-cluster {})
  */
 @Type("kubernetes-cluster")
-public class KubernetesClusterFinder extends AzureFinder<KubernetesCluster, KubernetesClusterResource> {
+public class KubernetesClusterFinder extends AzureFinder<AzureResourceManager, KubernetesCluster, KubernetesClusterResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/containerservice/KubernetesClusterResource.java
+++ b/src/main/java/gyro/azure/containerservice/KubernetesClusterResource.java
@@ -500,7 +500,7 @@ public class KubernetesClusterResource extends AzureResource implements Copyable
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
         KubernetesClusters kubernetesClusters = client.kubernetesClusters();
         KubernetesCluster cluster = kubernetesClusters.list().stream()
             .filter(o -> o.name().equals(getName()))
@@ -518,7 +518,7 @@ public class KubernetesClusterResource extends AzureResource implements Copyable
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         WithServicePrincipalClientId withServicePrincipalClientId = client.kubernetesClusters()
             .define(getName())
@@ -661,7 +661,7 @@ public class KubernetesClusterResource extends AzureResource implements Copyable
     public void update(
         GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         KubernetesCluster cluster = client.kubernetesClusters()
             .getByResourceGroup(getResourceGroup().getName(), getName());
@@ -792,7 +792,7 @@ public class KubernetesClusterResource extends AzureResource implements Copyable
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.kubernetesClusters().deleteByResourceGroup(getResourceGroup().getName(), getName());
     }

--- a/src/main/java/gyro/azure/cosmosdb/CosmosDBAccountFinder.java
+++ b/src/main/java/gyro/azure/cosmosdb/CosmosDBAccountFinder.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  *    cosmos-db: $(external-query azure::cosmos-db {})
  */
 @Type("cosmos-db")
-public class CosmosDBAccountFinder extends AzureFinder<CosmosDBAccount, CosmosDBAccountResource> {
+public class CosmosDBAccountFinder extends AzureFinder<AzureResourceManager, CosmosDBAccount, CosmosDBAccountResource> {
     private String id;
 
     /**

--- a/src/main/java/gyro/azure/cosmosdb/CosmosDBAccountResource.java
+++ b/src/main/java/gyro/azure/cosmosdb/CosmosDBAccountResource.java
@@ -287,7 +287,7 @@ public class CosmosDBAccountResource extends AzureResource implements Copyable<C
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CosmosDBAccount cosmosAccount = client.cosmosDBAccounts().getById(getId());
 
@@ -302,7 +302,7 @@ public class CosmosDBAccountResource extends AzureResource implements Copyable<C
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         WithKind withKind = client.cosmosDBAccounts()
                 .define(getName())
@@ -357,7 +357,7 @@ public class CosmosDBAccountResource extends AzureResource implements Copyable<C
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CosmosDBAccount.Update update = client.cosmosDBAccounts()
                 .getById(getId())
@@ -417,7 +417,7 @@ public class CosmosDBAccountResource extends AzureResource implements Copyable<C
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.cosmosDBAccounts().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/dns/ARecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/ARecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    a-record-set: $(external-query azure::a-record-set {})
  */
 @Type("a-record-set")
-public class ARecordSetFinder extends AzureFinder<ARecordSet, ARecordSetResource> {
+public class ARecordSetFinder extends AzureFinder<AzureResourceManager, ARecordSet, ARecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/ARecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/ARecordSetResource.java
@@ -160,7 +160,7 @@ public class ARecordSetResource extends AzureResource implements Copyable<ARecor
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         com.azure.resourcemanager.dns.models.ARecordSet aRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -178,7 +178,7 @@ public class ARecordSetResource extends AzureResource implements Copyable<ARecor
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.ARecordSetBlank<DnsZone.Update> updateARecordSetBlank = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -205,7 +205,7 @@ public class ARecordSetResource extends AzureResource implements Copyable<ARecor
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateARecordSet updateARecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateARecordSet(getName());
@@ -254,7 +254,7 @@ public class ARecordSetResource extends AzureResource implements Copyable<ARecor
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutARecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/AaaaRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/AaaaRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    aaaa-record-set: $(external-query azure::aaaa-record-set {})
  */
 @Type("aaaa-record-set")
-public class AaaaRecordSetFinder extends AzureFinder<AaaaRecordSet, AaaaRecordSetResource> {
+public class AaaaRecordSetFinder extends AzureFinder<AzureResourceManager, AaaaRecordSet, AaaaRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/AaaaRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/AaaaRecordSetResource.java
@@ -163,7 +163,7 @@ public class AaaaRecordSetResource extends AzureResource implements Copyable<Aaa
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         AaaaRecordSet aaaaRecordSet = client.dnsZones().getById(getDnsZone().getId()).aaaaRecordSets().getByName(getName());
 
@@ -178,7 +178,7 @@ public class AaaaRecordSetResource extends AzureResource implements Copyable<Aaa
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.AaaaRecordSetBlank<DnsZone.Update> defineAaaaRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().defineAaaaRecordSet(getName());
@@ -203,7 +203,7 @@ public class AaaaRecordSetResource extends AzureResource implements Copyable<Aaa
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateAaaaRecordSet updateAaaaRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateAaaaRecordSet(getName());
@@ -252,7 +252,7 @@ public class AaaaRecordSetResource extends AzureResource implements Copyable<Aaa
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutAaaaRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/CaaRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/CaaRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    caa-record-set: $(external-query azure::caa-record-set {})
  */
 @Type("caa-record-set")
-public class CaaRecordSetFinder extends AzureFinder<CaaRecordSet, CaaRecordSetResource> {
+public class CaaRecordSetFinder extends AzureFinder<AzureResourceManager, CaaRecordSet, CaaRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/CaaRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/CaaRecordSetResource.java
@@ -179,7 +179,7 @@ public class CaaRecordSetResource extends AzureResource implements Copyable<CaaR
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CaaRecordSet caaRecordSet = client.dnsZones().getById(getDnsZone().getId()).caaRecordSets().getByName(getName());
 
@@ -194,7 +194,7 @@ public class CaaRecordSetResource extends AzureResource implements Copyable<CaaR
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.CaaRecordSetBlank<DnsZone.Update> defineCaaRecordSet =
             client.dnsZones()
@@ -225,7 +225,7 @@ public class CaaRecordSetResource extends AzureResource implements Copyable<CaaR
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateCaaRecordSet updateCaaRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateCaaRecordSet(getName());
@@ -272,7 +272,7 @@ public class CaaRecordSetResource extends AzureResource implements Copyable<CaaR
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutCaaRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/CnameRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/CnameRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    cname-record-set: $(external-query azure::cname-record-set {})
  */
 @Type("cname-record-set")
-public class CnameRecordSetFinder extends AzureFinder<CnameRecordSet, CnameRecordSetResource> {
+public class CnameRecordSetFinder extends AzureFinder<AzureResourceManager, CnameRecordSet, CnameRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/CnameRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/CnameRecordSetResource.java
@@ -153,7 +153,7 @@ public class CnameRecordSetResource extends AzureResource implements Copyable<Cn
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         CnameRecordSet cnameRecordSet = client.dnsZones().getById(getDnsZone().getId()).cNameRecordSets().getByName(getName());
 
@@ -168,7 +168,7 @@ public class CnameRecordSetResource extends AzureResource implements Copyable<Cn
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.WithCNameRecordSetAttachable<DnsZone.Update> createCNameRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -191,7 +191,7 @@ public class CnameRecordSetResource extends AzureResource implements Copyable<Cn
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateCNameRecordSet updateCNameRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateCNameRecordSet(getName());
@@ -230,7 +230,7 @@ public class CnameRecordSetResource extends AzureResource implements Copyable<Cn
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutCaaRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/DnsZoneFinder.java
+++ b/src/main/java/gyro/azure/dns/DnsZoneFinder.java
@@ -16,17 +16,17 @@
 
 package gyro.azure.dns;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.dns.models.DnsZone;
 import com.psddev.dari.util.ObjectUtils;
 import gyro.azure.AzureFinder;
 import gyro.core.GyroException;
 import gyro.core.Type;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Query dns zone.
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  *    dns-zone: $(external-query azure::dns-zone {})
  */
 @Type("dns-zone")
-public class DnsZoneFinder extends AzureFinder<DnsZone, DnsZoneResource> {
+public class DnsZoneFinder extends AzureFinder<AzureResourceManager, DnsZone, DnsZoneResource> {
     private String id;
 
     /**

--- a/src/main/java/gyro/azure/dns/DnsZoneResource.java
+++ b/src/main/java/gyro/azure/dns/DnsZoneResource.java
@@ -167,7 +167,7 @@ public class DnsZoneResource extends AzureResource implements Copyable<DnsZone> 
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsZone dnsZone = client.dnsZones().getById(getId());
 
@@ -182,7 +182,7 @@ public class DnsZoneResource extends AzureResource implements Copyable<DnsZone> 
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsZone.DefinitionStages.WithCreate withCreate;
 
@@ -201,7 +201,7 @@ public class DnsZoneResource extends AzureResource implements Copyable<DnsZone> 
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsZone.Update update = client.dnsZones().getById(getId()).update();
 
@@ -214,7 +214,7 @@ public class DnsZoneResource extends AzureResource implements Copyable<DnsZone> 
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/dns/MxRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/MxRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    mx-record-set: $(external-query azure::mx-record-set {})
  */
 @Type("mx-record-set")
-public class MxRecordSetFinder extends AzureFinder<MxRecordSet, MxRecordSetResource> {
+public class MxRecordSetFinder extends AzureFinder<AzureResourceManager, MxRecordSet, MxRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/MxRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/MxRecordSetResource.java
@@ -177,7 +177,7 @@ public class MxRecordSetResource extends AzureResource implements Copyable<MxRec
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         MxRecordSet mxRecordSet = client.dnsZones().getById(getDnsZone().getId()).mxRecordSets().getByName(getName());
 
@@ -192,7 +192,7 @@ public class MxRecordSetResource extends AzureResource implements Copyable<MxRec
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.MXRecordSetBlank<DnsZone.Update> defineMXRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -221,7 +221,7 @@ public class MxRecordSetResource extends AzureResource implements Copyable<MxRec
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateMXRecordSet updateMXRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateMXRecordSet(getName());
@@ -281,7 +281,7 @@ public class MxRecordSetResource extends AzureResource implements Copyable<MxRec
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutMXRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/PtrRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/PtrRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    ptr-record-set: $(external-query azure::ptr-record-set {})
  */
 @Type("ptr-record-set")
-public class PtrRecordSetFinder extends AzureFinder<PtrRecordSet, PtrRecordSetResource> {
+public class PtrRecordSetFinder extends AzureFinder<AzureResourceManager, PtrRecordSet, PtrRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/PtrRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/PtrRecordSetResource.java
@@ -161,7 +161,7 @@ public class PtrRecordSetResource extends AzureResource implements Copyable<PtrR
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         PtrRecordSet ptrRecordSet = client.dnsZones().getById(getDnsZone().getId()).ptrRecordSets().getByName(getName());
 
@@ -175,7 +175,7 @@ public class PtrRecordSetResource extends AzureResource implements Copyable<PtrR
     }
 
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.PtrRecordSetBlank<DnsZone.Update> definePtrRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -203,7 +203,7 @@ public class PtrRecordSetResource extends AzureResource implements Copyable<PtrR
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdatePtrRecordSet updatePtrRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updatePtrRecordSet(getName());
@@ -252,7 +252,7 @@ public class PtrRecordSetResource extends AzureResource implements Copyable<PtrR
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutPtrRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/SrvRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/SrvRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    srv-record-set: $(external-query azure::srv-record-set {})
  */
 @Type("srv-record-set")
-public class SrvRecordSetFinder extends AzureFinder<SrvRecordSet, SrvRecordSetResource> {
+public class SrvRecordSetFinder extends AzureFinder<AzureResourceManager, SrvRecordSet, SrvRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/SrvRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/SrvRecordSetResource.java
@@ -174,7 +174,7 @@ public class SrvRecordSetResource extends AzureResource implements Copyable<SrvR
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SrvRecordSet srvRecordSet = client.dnsZones().getById(getDnsZone().getId()).srvRecordSets().getByName(getName());
 
@@ -189,7 +189,7 @@ public class SrvRecordSetResource extends AzureResource implements Copyable<SrvR
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.SrvRecordSetBlank<DnsZone.Update> defineSrvRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -216,7 +216,7 @@ public class SrvRecordSetResource extends AzureResource implements Copyable<SrvR
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateSrvRecordSet updateSrvRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateSrvRecordSet(getName());
@@ -262,7 +262,7 @@ public class SrvRecordSetResource extends AzureResource implements Copyable<SrvR
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutSrvRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/dns/TxtRecordSetFinder.java
+++ b/src/main/java/gyro/azure/dns/TxtRecordSetFinder.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  *    txt-record-set: $(external-query azure::txt-record-set {})
  */
 @Type("txt-record-set")
-public class TxtRecordSetFinder extends AzureFinder<TxtRecordSet, TxtRecordSetResource> {
+public class TxtRecordSetFinder extends AzureFinder<AzureResourceManager, TxtRecordSet, TxtRecordSetResource> {
     private String dnsZoneId;
     private String name;
 

--- a/src/main/java/gyro/azure/dns/TxtRecordSetResource.java
+++ b/src/main/java/gyro/azure/dns/TxtRecordSetResource.java
@@ -162,7 +162,7 @@ public class TxtRecordSetResource extends AzureResource implements Copyable<TxtR
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         TxtRecordSet txtRecordSet = client.dnsZones().getById(getDnsZone().getId()).txtRecordSets().getByName(getName());
 
@@ -177,7 +177,7 @@ public class TxtRecordSetResource extends AzureResource implements Copyable<TxtR
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateDefinitionStages.TxtRecordSetBlank<DnsZone.Update> defineTxtRecordSet = client.dnsZones()
             .getById(getDnsZone().getId())
@@ -204,7 +204,7 @@ public class TxtRecordSetResource extends AzureResource implements Copyable<TxtR
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         DnsRecordSet.UpdateTxtRecordSet updateTxtRecordSet =
                 client.dnsZones().getById(getDnsZone().getId()).update().updateTxtRecordSet(getName());
@@ -253,7 +253,7 @@ public class TxtRecordSetResource extends AzureResource implements Copyable<TxtR
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.dnsZones().getById(getDnsZone().getId()).update().withoutTxtRecordSet(getName()).apply();
     }

--- a/src/main/java/gyro/azure/identity/IdentityFinder.java
+++ b/src/main/java/gyro/azure/identity/IdentityFinder.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  *    identity: $(external-query azure::identity {})
  */
 @Type("identity")
-public class IdentityFinder extends AzureFinder<Identity, IdentityResource> {
+public class IdentityFinder extends AzureFinder<AzureResourceManager, Identity, IdentityResource> {
     private String id;
 
     /**

--- a/src/main/java/gyro/azure/identity/IdentityResource.java
+++ b/src/main/java/gyro/azure/identity/IdentityResource.java
@@ -164,7 +164,7 @@ public class IdentityResource extends AzureResource implements Copyable<Identity
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Identity identity = client.identities().getById(getId());
 
@@ -179,7 +179,7 @@ public class IdentityResource extends AzureResource implements Copyable<Identity
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Identity identity = client.identities().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -192,7 +192,7 @@ public class IdentityResource extends AzureResource implements Copyable<Identity
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Identity.Update update = client.identities().getById(getId()).update();
         IdentityResource oldResource = (IdentityResource) current;
@@ -212,7 +212,7 @@ public class IdentityResource extends AzureResource implements Copyable<Identity
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.identities().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/keyvault/KeyVaultCertificateFinder.java
+++ b/src/main/java/gyro/azure/keyvault/KeyVaultCertificateFinder.java
@@ -40,7 +40,7 @@ import gyro.core.Type;
  *    certificate: $(external-query azure::key-vault-certificate {resource-group: "resource-group-example", vault: "vault-example", name: "certificate-example"})
  */
 @Type("key-vault-certificate")
-public class KeyVaultCertificateFinder extends AzureFinder<KeyVaultCertificateWithPolicy, KeyVaultCertificateResource> {
+public class KeyVaultCertificateFinder extends AzureFinder<AzureResourceManager, KeyVaultCertificateWithPolicy, KeyVaultCertificateResource> {
 
     private String resourceGroup;
     private String vault;

--- a/src/main/java/gyro/azure/keyvault/KeyVaultFinder.java
+++ b/src/main/java/gyro/azure/keyvault/KeyVaultFinder.java
@@ -38,7 +38,7 @@ import gyro.core.Type;
  *    identity: $(external-query azure::key-vault {resource-group: "resource-group-example", name: "vault-example"})
  */
 @Type("key-vault")
-public class KeyVaultFinder extends AzureFinder<Vault, KeyVaultResource> {
+public class KeyVaultFinder extends AzureFinder<AzureResourceManager, Vault, KeyVaultResource> {
 
     private String resourceGroup;
     private String name;

--- a/src/main/java/gyro/azure/keyvault/KeyVaultKeyFinder.java
+++ b/src/main/java/gyro/azure/keyvault/KeyVaultKeyFinder.java
@@ -21,7 +21,7 @@ import gyro.core.Type;
  *    certificate: $(external-query azure::key-vault-key {resource-group: "resource-group-example", vault: "vault-example", name: "key-example"})
  */
 @Type("key-vault-key")
-public class KeyVaultKeyFinder extends AzureFinder<Key, KeyVaultKeyResource> {
+public class KeyVaultKeyFinder extends AzureFinder<AzureResourceManager, Key, KeyVaultKeyResource> {
 
     private String resourceGroup;
     private String vault;

--- a/src/main/java/gyro/azure/keyvault/KeyVaultResource.java
+++ b/src/main/java/gyro/azure/keyvault/KeyVaultResource.java
@@ -405,7 +405,7 @@ public class KeyVaultResource extends AzureResource implements Copyable<Vault> {
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Vault vault = client.vaults().getByResourceGroup(getResourceGroup().getName(), getName());
 
@@ -420,7 +420,7 @@ public class KeyVaultResource extends AzureResource implements Copyable<Vault> {
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Vault.DefinitionStages.WithCreate withCreate = client.vaults().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -463,7 +463,7 @@ public class KeyVaultResource extends AzureResource implements Copyable<Vault> {
     @Override
     public void update(
         GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Vault vault = client.vaults().getById(getId());
 
@@ -526,7 +526,7 @@ public class KeyVaultResource extends AzureResource implements Copyable<Vault> {
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.vaults().deleteById(getId());
 
@@ -536,7 +536,7 @@ public class KeyVaultResource extends AzureResource implements Copyable<Vault> {
     }
 
     Vault getKeyVault() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         return client.vaults().getByResourceGroup(getResourceGroup().getName(), getName());
     }

--- a/src/main/java/gyro/azure/keyvault/KeyVaultSecretFinder.java
+++ b/src/main/java/gyro/azure/keyvault/KeyVaultSecretFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    certificate: $(external-query azure::key-vault-secret {resource-group: "resource-group-example", vault: "vault-example", name: "secret-example"})
  */
 @Type("key-vault-secret")
-public class KeyVaultSecretFinder extends AzureFinder<Secret, KeyVaultSecretResource> {
+public class KeyVaultSecretFinder extends AzureFinder<AzureResourceManager, Secret, KeyVaultSecretResource> {
 
     private String resourceGroup;
     private String vault;

--- a/src/main/java/gyro/azure/network/ApplicationGatewayFinder.java
+++ b/src/main/java/gyro/azure/network/ApplicationGatewayFinder.java
@@ -38,7 +38,7 @@ import gyro.core.Type;
  */
 @Type("application-gateway")
 public class ApplicationGatewayFinder
-    extends AzureFinder<ApplicationGateway, ApplicationGatewayResource> {
+    extends AzureFinder<AzureResourceManager, ApplicationGateway, ApplicationGatewayResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/ApplicationGatewayResource.java
+++ b/src/main/java/gyro/azure/network/ApplicationGatewayResource.java
@@ -547,7 +547,7 @@ public class ApplicationGatewayResource extends AzureResource implements Copyabl
         Map<String, Integer> healthMap = new HashMap<>();
         int total = 0;
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
         ApplicationGateway applicationGateway = client.applicationGateways().getById(getId());
 
         if (applicationGateway != null) {
@@ -655,7 +655,7 @@ public class ApplicationGatewayResource extends AzureResource implements Copyabl
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ApplicationGateway applicationGateway = client.applicationGateways().getById(getId());
 
@@ -670,7 +670,7 @@ public class ApplicationGatewayResource extends AzureResource implements Copyabl
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ApplicationGateway.DefinitionStages.WithRequestRoutingRule withRequestRoutingRule = client.applicationGateways()
             .define(getName()).withRegion(Region.fromName(getRegion()))
@@ -735,7 +735,7 @@ public class ApplicationGatewayResource extends AzureResource implements Copyabl
 
     @Override
     public void update(GyroUI ui, State state, Resource resource, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ApplicationGateway applicationGateway = client.applicationGateways().getById(getId());
 
@@ -774,7 +774,7 @@ public class ApplicationGatewayResource extends AzureResource implements Copyabl
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.applicationGateways().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/network/ApplicationSecurityGroupFinder.java
+++ b/src/main/java/gyro/azure/network/ApplicationSecurityGroupFinder.java
@@ -38,7 +38,7 @@ import gyro.core.Type;
  */
 @Type("application-security-group")
 public class ApplicationSecurityGroupFinder
-    extends AzureFinder<ApplicationSecurityGroup, ApplicationSecurityGroupResource> {
+    extends AzureFinder<AzureResourceManager, ApplicationSecurityGroup, ApplicationSecurityGroupResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/ApplicationSecurityGroupResource.java
+++ b/src/main/java/gyro/azure/network/ApplicationSecurityGroupResource.java
@@ -180,7 +180,7 @@ public class ApplicationSecurityGroupResource extends AzureResource implements C
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ApplicationSecurityGroup applicationSecurityGroup = client.applicationSecurityGroups().getById(getId());
 
@@ -195,7 +195,7 @@ public class ApplicationSecurityGroupResource extends AzureResource implements C
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ApplicationSecurityGroup applicationSecurityGroup = client.applicationSecurityGroups().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -208,14 +208,14 @@ public class ApplicationSecurityGroupResource extends AzureResource implements C
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.applicationSecurityGroups().getById(getId()).update().withTags(getTags()).apply();
     }
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.applicationSecurityGroups().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/network/LoadBalancerFinder.java
+++ b/src/main/java/gyro/azure/network/LoadBalancerFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    load-balancer: $(external-query azure::load-balancer {})
  */
 @Type("load-balancer")
-public class LoadBalancerFinder extends AzureFinder<LoadBalancer, LoadBalancerResource> {
+public class LoadBalancerFinder extends AzureFinder<AzureResourceManager, LoadBalancer, LoadBalancerResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/LoadBalancerResource.java
+++ b/src/main/java/gyro/azure/network/LoadBalancerResource.java
@@ -386,7 +386,7 @@ public class LoadBalancerResource extends AzureResource implements Copyable<Load
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         LoadBalancer loadBalancer = client.loadBalancers().getById(getId());
 
@@ -401,7 +401,7 @@ public class LoadBalancerResource extends AzureResource implements Copyable<Load
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         LoadBalancer.DefinitionStages.WithLBRuleOrNat lb = client.loadBalancers()
             .define(getName())
@@ -506,7 +506,7 @@ public class LoadBalancerResource extends AzureResource implements Copyable<Load
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         LoadBalancer loadBalancer = client.loadBalancers().getById(getId());
 
@@ -633,7 +633,7 @@ public class LoadBalancerResource extends AzureResource implements Copyable<Load
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.loadBalancers().deleteByResourceGroup(getResourceGroup().getName(), getName());
     }

--- a/src/main/java/gyro/azure/network/NetworkFinder.java
+++ b/src/main/java/gyro/azure/network/NetworkFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    network: $(external-query azure::network {})
  */
 @Type("network")
-public class NetworkFinder extends AzureFinder<Network, NetworkResource> {
+public class NetworkFinder extends AzureFinder<AzureResourceManager, Network, NetworkResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/NetworkInterfaceFinder.java
+++ b/src/main/java/gyro/azure/network/NetworkInterfaceFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    network-interface: $(external-query azure::network-interface {})
  */
 @Type("network-interface")
-public class NetworkInterfaceFinder extends AzureFinder<NetworkInterface, NetworkInterfaceResource> {
+public class NetworkInterfaceFinder extends AzureFinder<AzureResourceManager, NetworkInterface, NetworkInterfaceResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
+++ b/src/main/java/gyro/azure/network/NetworkInterfaceResource.java
@@ -223,7 +223,7 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterface networkInterface = getNetworkInterface(client);
 
@@ -238,7 +238,7 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterface.DefinitionStages.WithPrimaryPrivateIP withPrimaryPrivateIP = client.networkInterfaces()
             .define(getName())
@@ -286,7 +286,7 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterface networkInterface = getNetworkInterface(client);
 
@@ -316,7 +316,7 @@ public class NetworkInterfaceResource extends AzureResource implements Copyable<
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.networkInterfaces().deleteByResourceGroup(getResourceGroup().getName(), getName());
     }

--- a/src/main/java/gyro/azure/network/NetworkResource.java
+++ b/src/main/java/gyro/azure/network/NetworkResource.java
@@ -245,7 +245,7 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Network network = client.networks().getById(getId());
 
@@ -260,7 +260,7 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Network.DefinitionStages.WithCreate networkDefWithoutAddress = client.networks()
             .define(getName())
@@ -284,7 +284,7 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Network network = client.networks().getById(getId());
 
@@ -322,7 +322,7 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.networks().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/network/NetworkSecurityGroupFinder.java
+++ b/src/main/java/gyro/azure/network/NetworkSecurityGroupFinder.java
@@ -38,7 +38,7 @@ import gyro.core.Type;
  */
 @Type("network-security-group")
 public class NetworkSecurityGroupFinder
-    extends AzureFinder<NetworkSecurityGroup, NetworkSecurityGroupResource> {
+    extends AzureFinder<AzureResourceManager, NetworkSecurityGroup, NetworkSecurityGroupResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/NetworkSecurityGroupResource.java
+++ b/src/main/java/gyro/azure/network/NetworkSecurityGroupResource.java
@@ -171,7 +171,7 @@ public class NetworkSecurityGroupResource extends AzureResource implements Copya
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroup networkSecurityGroup = client.networkSecurityGroups().getById(getId());
 
@@ -186,7 +186,7 @@ public class NetworkSecurityGroupResource extends AzureResource implements Copya
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroup networkSecurityGroup = client.networkSecurityGroups()
             .define(getName())
@@ -200,7 +200,7 @@ public class NetworkSecurityGroupResource extends AzureResource implements Copya
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroup networkSecurityGroup = client.networkSecurityGroups().getById(getId());
 
@@ -209,7 +209,7 @@ public class NetworkSecurityGroupResource extends AzureResource implements Copya
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.networkSecurityGroups().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/network/NetworkSecurityGroupRuleResource.java
+++ b/src/main/java/gyro/azure/network/NetworkSecurityGroupRuleResource.java
@@ -290,7 +290,7 @@ public class NetworkSecurityGroupRuleResource extends AzureResource implements C
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroupResource parent = (NetworkSecurityGroupResource) parent();
 
@@ -356,7 +356,7 @@ public class NetworkSecurityGroupRuleResource extends AzureResource implements C
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroupResource parent = (NetworkSecurityGroupResource) parent();
 
@@ -411,7 +411,7 @@ public class NetworkSecurityGroupRuleResource extends AzureResource implements C
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkSecurityGroupResource parent = (NetworkSecurityGroupResource) parent();
 

--- a/src/main/java/gyro/azure/network/NicIpConfigurationResource.java
+++ b/src/main/java/gyro/azure/network/NicIpConfigurationResource.java
@@ -185,7 +185,7 @@ public class NicIpConfigurationResource extends AzureResource implements Copyabl
             return;
         }
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterfaceResource parent = (NetworkInterfaceResource) parent();
 
@@ -229,7 +229,7 @@ public class NicIpConfigurationResource extends AzureResource implements Copyabl
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterfaceResource parent = (NetworkInterfaceResource) parent();
 
@@ -303,7 +303,7 @@ public class NicIpConfigurationResource extends AzureResource implements Copyabl
             return;
         }
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkInterfaceResource parent = (NetworkInterfaceResource) parent();
 

--- a/src/main/java/gyro/azure/network/PublicIpAddressFinder.java
+++ b/src/main/java/gyro/azure/network/PublicIpAddressFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    public-ip-address: $(external-query azure::public-ip-address {})
  */
 @Type("public-ip-address")
-public class PublicIpAddressFinder extends AzureFinder<PublicIpAddress, PublicIpAddressResource> {
+public class PublicIpAddressFinder extends AzureFinder<AzureResourceManager, PublicIpAddress, PublicIpAddressResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/PublicIpAddressResource.java
+++ b/src/main/java/gyro/azure/network/PublicIpAddressResource.java
@@ -319,7 +319,7 @@ public class PublicIpAddressResource extends AzureResource implements Copyable<P
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         PublicIpAddress publicIpAddress = client.publicIpAddresses().getById(getId());
 
@@ -334,7 +334,7 @@ public class PublicIpAddressResource extends AzureResource implements Copyable<P
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         PublicIpAddress.DefinitionStages.WithCreate withCreate = client.publicIpAddresses()
             .define(getName())
@@ -382,7 +382,7 @@ public class PublicIpAddressResource extends AzureResource implements Copyable<P
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         PublicIpAddress publicIpAddress = client.publicIpAddresses().getById(getId());
 
@@ -425,7 +425,7 @@ public class PublicIpAddressResource extends AzureResource implements Copyable<P
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
         client.publicIpAddresses().deleteById(getId());
     }
 

--- a/src/main/java/gyro/azure/network/RouteTableFinder.java
+++ b/src/main/java/gyro/azure/network/RouteTableFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    route-table: $(external-query azure::route-table {})
  */
 @Type("route-table")
-public class RouteTableFinder extends AzureFinder<RouteTable, RouteTableResource> {
+public class RouteTableFinder extends AzureFinder<AzureResourceManager, RouteTable, RouteTableResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/network/RouteTableResource.java
+++ b/src/main/java/gyro/azure/network/RouteTableResource.java
@@ -176,7 +176,7 @@ public class RouteTableResource extends AzureResource implements Copyable<RouteT
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         RouteTable routeTable = client.routeTables().getById(getId());
 
@@ -191,7 +191,7 @@ public class RouteTableResource extends AzureResource implements Copyable<RouteT
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         RouteTable.DefinitionStages.WithCreate withCreate;
         withCreate = client.routeTables().define(getName())
@@ -220,7 +220,7 @@ public class RouteTableResource extends AzureResource implements Copyable<RouteT
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         RouteTableResource currentResource = (RouteTableResource) current;
 
@@ -255,7 +255,7 @@ public class RouteTableResource extends AzureResource implements Copyable<RouteT
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.routeTables().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/network/SubnetResource.java
+++ b/src/main/java/gyro/azure/network/SubnetResource.java
@@ -160,7 +160,7 @@ public class SubnetResource extends AzureResource implements Copyable<Subnet> {
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkResource parent = (NetworkResource) parent();
 
@@ -190,7 +190,7 @@ public class SubnetResource extends AzureResource implements Copyable<Subnet> {
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkResource parent = (NetworkResource) parent();
 
@@ -237,7 +237,7 @@ public class SubnetResource extends AzureResource implements Copyable<Subnet> {
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         NetworkResource parent = (NetworkResource) parent();
 

--- a/src/main/java/gyro/azure/registries/RegistryFinder.java
+++ b/src/main/java/gyro/azure/registries/RegistryFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    registry: $(external-query azure::registry {})
  */
 @Type("registry")
-public class RegistryFinder extends AzureFinder<Registry, RegistryResource> {
+public class RegistryFinder extends AzureFinder<AzureResourceManager, Registry, RegistryResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/registries/RegistryResource.java
+++ b/src/main/java/gyro/azure/registries/RegistryResource.java
@@ -244,7 +244,7 @@ public class RegistryResource extends AzureResource implements Copyable<Registry
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Registry registry = client.containerRegistries()
             .getByResourceGroup(getResourceGroup().getName(), getName());
@@ -260,7 +260,7 @@ public class RegistryResource extends AzureResource implements Copyable<Registry
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Registry.DefinitionStages.WithSku withSku = client.containerRegistries()
             .define(getName())
@@ -315,7 +315,7 @@ public class RegistryResource extends AzureResource implements Copyable<Registry
     @Override
     public void update(
         GyroUI ui, State state, Resource current, Set<String> changedFieldNames) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         Registry registry = client.containerRegistries()
             .getByResourceGroup(getResourceGroup().getName(), getName());
@@ -366,7 +366,7 @@ public class RegistryResource extends AzureResource implements Copyable<Registry
 
     @Override
     public void delete(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.containerRegistries().deleteByResourceGroup(getResourceGroup().getName(), getName());
     }

--- a/src/main/java/gyro/azure/resources/ResourceGroupFinder.java
+++ b/src/main/java/gyro/azure/resources/ResourceGroupFinder.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
  *    resource-group: $(external-query azure::resource-group {})
  */
 @Type("resource-group")
-public class ResourceGroupFinder extends AzureFinder<ResourceGroup, ResourceGroupResource> {
+public class ResourceGroupFinder extends AzureFinder<AzureResourceManager, ResourceGroup, ResourceGroupResource> {
     private String name;
 
     /**

--- a/src/main/java/gyro/azure/resources/ResourceGroupResource.java
+++ b/src/main/java/gyro/azure/resources/ResourceGroupResource.java
@@ -107,7 +107,7 @@ public class ResourceGroupResource extends AzureResource implements Copyable<Res
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         if (!client.resourceGroups().contain(getName())) {
             return false;
@@ -121,7 +121,7 @@ public class ResourceGroupResource extends AzureResource implements Copyable<Res
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ResourceGroup resourceGroup = client.resourceGroups()
             .define(getName())
@@ -134,7 +134,7 @@ public class ResourceGroupResource extends AzureResource implements Copyable<Res
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ResourceGroup resourceGroup = client.resourceGroups().getByName(getName());
 
@@ -143,7 +143,7 @@ public class ResourceGroupResource extends AzureResource implements Copyable<Res
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.resourceGroups().deleteByName(getName());
     }

--- a/src/main/java/gyro/azure/sql/SqlDatabaseFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlDatabaseFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  *    sql-database: $(external-query azure::sql-database {})
  */
 @Type("sql-database")
-public class SqlDatabaseFinder extends AzureFinder<SqlDatabase, SqlDatabaseResource> {
+public class SqlDatabaseFinder extends AzureFinder<AzureResourceManager, SqlDatabase, SqlDatabaseResource> {
 
     private String sqlServerId;
     private String name;

--- a/src/main/java/gyro/azure/sql/SqlDatabaseResource.java
+++ b/src/main/java/gyro/azure/sql/SqlDatabaseResource.java
@@ -330,7 +330,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlDatabase database = getSqlDatabase(client);
 
@@ -345,7 +345,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlDatabaseOperations.DefinitionStages.WithAllDifferentOptions buildDatabase = client.sqlServers()
             .getById(getSqlServer().getId())
@@ -452,7 +452,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlDatabase.Update update = getSqlDatabase(client).update();
 
@@ -492,7 +492,7 @@ public class SqlDatabaseResource extends AzureResource implements Copyable<SqlDa
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlDatabase sqlDatabase = getSqlDatabase(client);
         if (sqlDatabase != null) {

--- a/src/main/java/gyro/azure/sql/SqlElasticPoolFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlElasticPoolFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  *    sql-elastic-pool: $(external-query azure::sql-elastic-pool {})
  */
 @Type("sql-elastic-pool")
-public class SqlElasticPoolFinder extends AzureFinder<SqlElasticPool, SqlElasticPoolResource> {
+public class SqlElasticPoolFinder extends AzureFinder<AzureResourceManager, SqlElasticPool, SqlElasticPoolResource> {
 
     private String sqlServerId;
     private String name;

--- a/src/main/java/gyro/azure/sql/SqlElasticPoolResource.java
+++ b/src/main/java/gyro/azure/sql/SqlElasticPoolResource.java
@@ -245,7 +245,7 @@ public class SqlElasticPoolResource extends AzureResource implements Copyable<Sq
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlElasticPool elasticPool = getSqlElasticPool(client);
 
@@ -264,7 +264,7 @@ public class SqlElasticPoolResource extends AzureResource implements Copyable<Sq
             throw new GyroException("You must provide a sql server resource.");
         }
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlElasticPoolOperations.DefinitionStages.WithEdition buildPool = client.sqlServers()
             .getById(getSqlServer().getId())
@@ -309,7 +309,7 @@ public class SqlElasticPoolResource extends AzureResource implements Copyable<Sq
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlElasticPool.Update update = getSqlElasticPool(client).update();
 
@@ -338,7 +338,7 @@ public class SqlElasticPoolResource extends AzureResource implements Copyable<Sq
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlElasticPool sqlElasticPool = getSqlElasticPool(client);
         sqlElasticPool.listDatabases().stream().map(SqlDatabase::name).forEach(sqlElasticPool::removeDatabase);

--- a/src/main/java/gyro/azure/sql/SqlFailoverGroupFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlFailoverGroupFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  *    sql-failover-group: $(external-query azure::sql-failover-group {})
  */
 @Type("sql-failover-group")
-public class SqlFailoverGroupFinder extends AzureFinder<SqlFailoverGroup, SqlFailoverGroupResource> {
+public class SqlFailoverGroupFinder extends AzureFinder<AzureResourceManager, SqlFailoverGroup, SqlFailoverGroupResource> {
 
     private String sqlServerId;
     private String name;

--- a/src/main/java/gyro/azure/sql/SqlFailoverGroupResource.java
+++ b/src/main/java/gyro/azure/sql/SqlFailoverGroupResource.java
@@ -212,7 +212,7 @@ public class SqlFailoverGroupResource extends AzureResource implements Copyable<
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFailoverGroup failoverGroup = getSqlFailoverGroup(client);
 
@@ -227,7 +227,7 @@ public class SqlFailoverGroupResource extends AzureResource implements Copyable<
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFailoverGroupOperations.DefinitionStages.WithReadWriteEndpointPolicy buildFailoverGroup = client.sqlServers()
             .getById(getSqlServer().getId())
@@ -269,7 +269,7 @@ public class SqlFailoverGroupResource extends AzureResource implements Copyable<
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFailoverGroup.Update update = getSqlFailoverGroup(client).update();
 
@@ -311,7 +311,7 @@ public class SqlFailoverGroupResource extends AzureResource implements Copyable<
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFailoverGroup sqlFailoverGroup = getSqlFailoverGroup(client);
 

--- a/src/main/java/gyro/azure/sql/SqlFirewallRuleFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlFirewallRuleFinder.java
@@ -39,7 +39,7 @@ import gyro.core.Type;
  *    sql-firewall-rule: $(external-query azure::sql-firewall-rule {})
  */
 @Type("sql-firewall-rule")
-public class SqlFirewallRuleFinder extends AzureFinder<SqlFirewallRule, SqlFirewallRuleResource> {
+public class SqlFirewallRuleFinder extends AzureFinder<AzureResourceManager, SqlFirewallRule, SqlFirewallRuleResource> {
 
     private String sqlServerId;
     private String name;

--- a/src/main/java/gyro/azure/sql/SqlFirewallRuleResource.java
+++ b/src/main/java/gyro/azure/sql/SqlFirewallRuleResource.java
@@ -129,7 +129,7 @@ public class SqlFirewallRuleResource extends AzureResource implements Copyable<S
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFirewallRule firewallRule = getSqlFirewallRule(client);
 
@@ -154,7 +154,7 @@ public class SqlFirewallRuleResource extends AzureResource implements Copyable<S
             throw new GyroException("You must provide a sql server resource.");
         }
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFirewallRuleOperations.DefinitionStages.WithIpAddressRange rule = client.sqlServers()
             .getById(getSqlServer().getId())
@@ -175,7 +175,7 @@ public class SqlFirewallRuleResource extends AzureResource implements Copyable<S
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFirewallRule.Update update = getSqlFirewallRule(client).update();
 
@@ -190,7 +190,7 @@ public class SqlFirewallRuleResource extends AzureResource implements Copyable<S
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlFirewallRule sqlFirewallRule = getSqlFirewallRule(client);
 

--- a/src/main/java/gyro/azure/sql/SqlServerFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlServerFinder.java
@@ -37,7 +37,7 @@ import gyro.core.Type;
  *    sql-server: $(external-query azure::sql-server {})
  */
 @Type("sql-server")
-public class SqlServerFinder extends AzureFinder<SqlServer, SqlServerResource> {
+public class SqlServerFinder extends AzureFinder<AzureResourceManager, SqlServer, SqlServerResource> {
 
     private String id;
 

--- a/src/main/java/gyro/azure/sql/SqlServerResource.java
+++ b/src/main/java/gyro/azure/sql/SqlServerResource.java
@@ -202,7 +202,7 @@ public class SqlServerResource extends AzureResource implements Copyable<SqlServ
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlServer sqlServer = client.sqlServers().getById(getId());
 
@@ -217,7 +217,7 @@ public class SqlServerResource extends AzureResource implements Copyable<SqlServ
 
     @Override
     public void create(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlServer.DefinitionStages.WithCreate withCreate = client.sqlServers().define(getName())
             .withRegion(Region.fromName(getRegion()))
@@ -242,7 +242,7 @@ public class SqlServerResource extends AzureResource implements Copyable<SqlServ
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlServer.Update update = client.sqlServers().getById(getId()).update();
 
@@ -257,7 +257,7 @@ public class SqlServerResource extends AzureResource implements Copyable<SqlServ
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.sqlServers().deleteById(getId());
     }

--- a/src/main/java/gyro/azure/sql/SqlVirtualNetworkRuleFinder.java
+++ b/src/main/java/gyro/azure/sql/SqlVirtualNetworkRuleFinder.java
@@ -40,7 +40,7 @@ import gyro.core.Type;
  */
 @Type("sql-virtual-network-rule")
 public class SqlVirtualNetworkRuleFinder
-    extends AzureFinder<SqlVirtualNetworkRule, SqlVirtualNetworkRuleResource> {
+    extends AzureFinder<AzureResourceManager, SqlVirtualNetworkRule, SqlVirtualNetworkRuleResource> {
 
     private String sqlServerId;
     private String name;

--- a/src/main/java/gyro/azure/sql/SqlVirtualNetworkRuleResource.java
+++ b/src/main/java/gyro/azure/sql/SqlVirtualNetworkRuleResource.java
@@ -131,7 +131,7 @@ public class SqlVirtualNetworkRuleResource extends AzureResource implements Copy
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlVirtualNetworkRule virtualNetworkRule = getVirtualNetworkRule(client);
 
@@ -150,7 +150,7 @@ public class SqlVirtualNetworkRuleResource extends AzureResource implements Copy
             throw new GyroException("You must provide a sql server resource.");
         }
 
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlVirtualNetworkRuleOperations.DefinitionStages.WithServiceEndpoint withServiceEndpoint = client.sqlServers()
             .getById(getSqlServer().getId())
@@ -165,7 +165,7 @@ public class SqlVirtualNetworkRuleResource extends AzureResource implements Copy
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedProperties) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlVirtualNetworkRule.Update update = getVirtualNetworkRule(client)
             .update()
@@ -176,7 +176,7 @@ public class SqlVirtualNetworkRuleResource extends AzureResource implements Copy
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         SqlVirtualNetworkRule virtualNetworkRule = getVirtualNetworkRule(client);
         if (virtualNetworkRule != null) {

--- a/src/main/java/gyro/azure/storage/StorageAccountFinder.java
+++ b/src/main/java/gyro/azure/storage/StorageAccountFinder.java
@@ -28,7 +28,7 @@ import gyro.core.GyroException;
 import gyro.core.Type;
 
 @Type("storage-account")
-public class StorageAccountFinder extends AzureFinder<StorageAccount, StorageAccountResource> {
+public class StorageAccountFinder extends AzureFinder<AzureResourceManager, StorageAccount, StorageAccountResource> {
 
     private String id;
     private String resourceGroup;

--- a/src/main/java/gyro/azure/storage/StorageAccountResource.java
+++ b/src/main/java/gyro/azure/storage/StorageAccountResource.java
@@ -232,7 +232,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
 
     @Override
     public boolean refresh() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         StorageAccount storageAccount = client.storageAccounts()
             .getByResourceGroup(getResourceGroup().getName(), getName());
@@ -248,7 +248,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
 
     @Override
     public void create(GyroUI ui, State state) throws URISyntaxException, InvalidKeyException {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         StorageAccount.DefinitionStages.WithCreate withCreate = client.storageAccounts()
             .define(getName())
@@ -280,7 +280,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames)
         throws URISyntaxException, InvalidKeyException {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         StorageAccount storageAccount = client.storageAccounts().getById(getId());
         StorageAccount.Update update = storageAccount.update();
@@ -308,7 +308,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         client.storageAccounts().deleteById(getId());
     }
@@ -324,7 +324,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
         Map<String, String> keys = new HashMap<>();
 
         if (getId() != null) {
-            AzureResourceManager client = createClient();
+            AzureResourceManager client = createClient(AzureResourceManager.class);
 
             StorageAccount storageAccount = client.storageAccounts().getById(getId());
             storageAccount.getKeys().forEach(e -> keys.put(e.keyName(), e.value()));
@@ -334,7 +334,7 @@ public class StorageAccountResource extends AzureResource implements Copyable<St
     }
 
     protected StorageAccount getStorageAccount() {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         return client.storageAccounts().getById(getId());
     }

--- a/src/main/java/gyro/azure/storage/StorageLifeCycle.java
+++ b/src/main/java/gyro/azure/storage/StorageLifeCycle.java
@@ -133,7 +133,7 @@ public class StorageLifeCycle extends AzureResource implements Copyable<Manageme
 
     @Override
     public void create(GyroUI ui, State state) throws Exception {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         StorageAccountResource parent = (StorageAccountResource) parent();
 
@@ -192,7 +192,7 @@ public class StorageLifeCycle extends AzureResource implements Copyable<Manageme
 
     @Override
     public void update(GyroUI ui, State state, Resource current, Set<String> changedFieldNames) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         ManagementPolicySchema policySchema = new ManagementPolicySchema();
         policySchema.withRules(getRule().stream().map(PolicyRule::toManagementPolicyRule).collect(Collectors.toList()));
@@ -205,7 +205,7 @@ public class StorageLifeCycle extends AzureResource implements Copyable<Manageme
 
     @Override
     public void delete(GyroUI ui, State state) {
-        AzureResourceManager client = createClient();
+        AzureResourceManager client = createClient(AzureResourceManager.class);
 
         StorageAccountResource parent = (StorageAccountResource) parent();
         StorageAccount storageAccount = client.storageAccounts().getById(parent.getId());


### PR DESCRIPTION
Support multiple clients for base azure resource, credentials and finder implementations.

The base azure implementations (`AzureResource`, `AzureFinder` and `AzureCredentials`) currently only support a single client type (`AzureResourceManager`).
With the introduction of a new client type (`CommunicationManager`) we need a way to generalize extending the `AzureResource` and `AzureFinder` models, which can support multiple clients (See [gyro-aws-provider](https://github.com/perfectsense/gyro-aws-provider/blob/master/src/main/java/gyro/aws/AwsFinder.java#L32)).

This PR:
 - Updates every `createClient` call to specify the client class (similar to [gyro-aws-provider](https://github.com/perfectsense/gyro-aws-provider/blob/master/src/main/java/gyro/aws/AwsResource.java#L54))
 - Provides a generic way of creating clients and extending the Finder implementation where you can specify the client type that resource will depend on.