### PR TITLE
Miscellaneous bugfixs from release

### DIFF
--- a/src/main/java/gyro/azure/containerservice/ClusterLoadBalancerProfile.java
+++ b/src/main/java/gyro/azure/containerservice/ClusterLoadBalancerProfile.java
@@ -66,10 +66,6 @@ public class ClusterLoadBalancerProfile extends Diffable implements Copyable<Man
      * If set to ``true`` enables multiple standard load balancer. Defaults to ``false``.
      */
     public Boolean getEnableMultipleStandardLoadBalancers() {
-        if (enableMultipleStandardLoadBalancers == null) {
-            enableMultipleStandardLoadBalancers = false;
-        }
-
         return enableMultipleStandardLoadBalancers;
     }
 
@@ -171,7 +167,9 @@ public class ClusterLoadBalancerProfile extends Diffable implements Copyable<Man
             profile.withAllocatedOutboundPorts(getAllocatedOutboundPorts());
         }
 
-        profile.withEnableMultipleStandardLoadBalancers(getEnableMultipleStandardLoadBalancers());
+        if (getEnableMultipleStandardLoadBalancers() != null) {
+            profile.withEnableMultipleStandardLoadBalancers(getEnableMultipleStandardLoadBalancers());
+        }
 
         if (getIdleTimeoutInMinutes() != null) {
             profile.withIdleTimeoutInMinutes(getIdleTimeoutInMinutes());

--- a/src/main/java/gyro/azure/network/NetworkResource.java
+++ b/src/main/java/gyro/azure/network/NetworkResource.java
@@ -273,13 +273,16 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
             withAddressSpace = networkDefWithoutAddress.withAddressSpace(addressSpace);
         }
 
+        withAddressSpace = withAddressSpace.withSubnets(getSubnet().stream()
+            .collect(Collectors.toMap(SubnetResource::getName, SubnetResource::getAddressPrefix)));
+
         Network network = withAddressSpace
             .withTags(getTags())
             .create();
 
-        network = network.update().withoutSubnet("subnet1").apply();
-
         copyFrom(network);
+
+        getSubnet().clear();
     }
 
     @Override

--- a/src/main/java/gyro/azure/network/NetworkResource.java
+++ b/src/main/java/gyro/azure/network/NetworkResource.java
@@ -132,6 +132,7 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
      *
      * @subresource gyro.azure.network.SubnetResource
      */
+    @Required
     public Set<SubnetResource> getSubnet() {
         if (subnet == null) {
             subnet = new HashSet<>();
@@ -281,8 +282,6 @@ public class NetworkResource extends AzureResource implements Copyable<Network> 
             .create();
 
         copyFrom(network);
-
-        getSubnet().clear();
     }
 
     @Override

--- a/src/main/java/gyro/azure/network/SubnetResource.java
+++ b/src/main/java/gyro/azure/network/SubnetResource.java
@@ -187,6 +187,8 @@ public class SubnetResource extends AzureResource implements Copyable<Subnet> {
 
         Network response = updateWithAttach.attach().apply();
         setId(response.subnets().get(getName()).id());
+
+        parent.refresh();
     }
 
     @Override

--- a/src/main/java/gyro/azure/network/SubnetResource.java
+++ b/src/main/java/gyro/azure/network/SubnetResource.java
@@ -151,6 +151,7 @@ public class SubnetResource extends AzureResource implements Copyable<Subnet> {
             RouteTableResource.class,
             subnet.routeTableId()) : null);
         setServiceEndpoints(toServiceEndpoints(subnet.servicesWithAccess()));
+        setId(subnet.innerModel().id());
     }
 
     @Override

--- a/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
+++ b/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
@@ -160,8 +160,6 @@ public class CloudBlobContainerResource extends AzureResource implements Copyabl
             blobContainer.create();
 
         } catch (BlobStorageException ex) {
-            System.out.println(ex.getErrorCode());
-            System.out.println(ex.getMessage());
             throw new GyroException(
                 String.format("Could not create container [%s] as it already exists", getName()), ex);
         }

--- a/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
+++ b/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
@@ -157,10 +157,12 @@ public class CloudBlobContainerResource extends AzureResource implements Copyabl
 
         state.save();
 
-        blobContainer.setAccessPolicy(PublicAccessType.fromString(getPublicAccess()), null);
+        if (getPublicAccess() != null) {
+            blobContainer.setAccessPolicy(PublicAccessType.fromString(getPublicAccess()), null);
 
-        if (!getMetadata().isEmpty()) {
-            blobContainer.setMetadata(getMetadata());
+            if (!getMetadata().isEmpty()) {
+                blobContainer.setMetadata(getMetadata());
+            }
         }
 
         copyFrom(blobContainer);

--- a/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
+++ b/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
@@ -77,7 +77,6 @@ public class CloudBlobContainerResource extends AzureResource implements Copyabl
     /**
      * The public access of the container.
      */
-    @Required
     @ValidStrings({ "blob", "container" })
     @Updatable
     public String getPublicAccess() {

--- a/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
+++ b/src/main/java/gyro/azure/storage/CloudBlobContainerResource.java
@@ -164,6 +164,8 @@ public class CloudBlobContainerResource extends AzureResource implements Copyabl
                 String.format("Could not create container [%s] as it already exists", getName()), ex);
         }
 
+        state.save();
+
         if (!getMetadata().isEmpty()) {
             blobContainer.setMetadata(getMetadata());
         }


### PR DESCRIPTION
- Fixes subnet creation
  - Networks were created with a default subnet covering the entire network range if one wasn't provided
  - this made it impossible to create other subnets
  - the fix was to specify subnets in the network creation call
- The `enableMultipleStandardLoadBalancers` in the K8s cluster network profile was getting a default value set, which is no longer supported by the api.
- Fixes public container creation
  - There is a delay for the StorageAccount to actually become public.
  - Unfortunately the api doesn't really provide a good way to determine if the account is actually public.
  - The fix was to add a wait/retry on the container creation call which results in a 409 error if the creation isn't successful