### PR TITLE
Use azure cli credentials if client and key are not configured

### DIFF
--- a/src/main/java/gyro/azure/AzureCredentials.java
+++ b/src/main/java/gyro/azure/AzureCredentials.java
@@ -133,7 +133,7 @@ public class AzureCredentials extends Credentials {
     }
 
     public TokenCredential getTokenCredential(String tenant, String client, String key) {
-        if (client == null || key == null) {
+        if (tenant == null || client == null || key == null) {
             return new AzureCliCredentialBuilder().build();
         }
 

--- a/src/main/java/gyro/azure/AzureCredentials.java
+++ b/src/main/java/gyro/azure/AzureCredentials.java
@@ -24,6 +24,7 @@ import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder;
 import com.azure.core.management.AzureEnvironment;
 import com.azure.core.management.profile.AzureProfile;
+import com.azure.identity.AzureCliCredentialBuilder;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.azure.resourcemanager.communication.CommunicationManager;
@@ -132,6 +133,10 @@ public class AzureCredentials extends Credentials {
     }
 
     public TokenCredential getTokenCredential(String tenant, String client, String key) {
+        if (client == null || key == null) {
+            return new AzureCliCredentialBuilder().build();
+        }
+
         return new ClientSecretCredentialBuilder()
             .clientId(ObjectUtils.to(String.class, client))
             .clientSecret(ObjectUtils.to(String.class, key))


### PR DESCRIPTION
Use azure cli credentials if client and key are not configured in the credentials file.